### PR TITLE
Documentation: Use react-docgen-typescript to add props

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,6 +43,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "prettier": "^3.0.3",
+        "react-docgen-typescript": "^2.2.2",
         "react-styleguidist": "^13.1.1",
         "ts-loader": "^9.4.4",
         "webpack": "^5.88.2"
@@ -21277,6 +21278,15 @@
       },
       "peerDependencies": {
         "react-docgen": "^3.0.0 || ^4.0.0 || ^5.0.0-beta || ^5.0.0"
+      }
+    },
+    "node_modules/react-docgen-typescript": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
+      "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">= 4.3.x"
       }
     },
     "node_modules/react-docgen/node_modules/commander": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,6 +64,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "prettier": "^3.0.3",
+    "react-docgen-typescript": "^2.2.2",
     "react-styleguidist": "^13.1.1",
     "ts-loader": "^9.4.4",
     "webpack": "^5.88.2"

--- a/frontend/styleguide.config.js
+++ b/frontend/styleguide.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  propsParser: require('react-docgen-typescript').withDefaultConfig({
+    skipChildrenPropWithoutDoc: false,
+  }).parse,
   components: ['src/App.tsx', 'src/Components/**/*.{tsx,jsx,js,ts}'],
   ignore: [
     '**/__tests__/**',


### PR DESCRIPTION
This allows to show a table for the props properties of each component

![image](https://github.com/DTU-SE-Group-D/LiRA-Viz/assets/65665540/ef8aeb38-f1aa-4385-ac44-6a69d556b1ea)
