### PR TITLE
ForceMapUpdate: Allow to force update the map or to go to specific position

### DIFF
--- a/frontend/src/Components/Map/ForceMapUpdate.tsx
+++ b/frontend/src/Components/Map/ForceMapUpdate.tsx
@@ -1,0 +1,31 @@
+import { LatLng } from '../../models/models';
+import { useMap } from 'react-leaflet';
+import React, { useEffect } from 'react';
+
+interface Props {
+  /** A modification of this value is used to trigger an update of the map */
+  triggerUpdate: number;
+  /** The coordinates of the map center*/
+  position?: LatLng;
+}
+
+/**
+ * This component is used to force an update of the map. It is used in conjunction with the useMap hook.
+ */
+const ForceMapUpdate: React.FC<Props> = ({ triggerUpdate, position }) => {
+  const map = useMap();
+
+  useEffect(() => {
+    map.invalidateSize();
+  }, [triggerUpdate]);
+
+  useEffect(() => {
+    if (position) {
+      map.flyTo(position);
+    }
+  }, [position]);
+
+  return null;
+};
+
+export default ForceMapUpdate;


### PR DESCRIPTION
A small component to either force update the map (for the slip package) or to go to a specific position on the map (for #54 )