### PR TITLE
Select Survey & Inspect

### DIFF
--- a/backend/src/models.ts
+++ b/backend/src/models.ts
@@ -23,6 +23,7 @@ export interface ISurvey {
   id: string;
   geometry: number[][];
   data: SurveyConditions[];
+  timestamp: string;
 }
 
 /**

--- a/frontend/src/Components/Map/InfoCard.tsx
+++ b/frontend/src/Components/Map/InfoCard.tsx
@@ -2,50 +2,72 @@ import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../../css/roadinfo_card.css';
 import { IRoad } from '../../models/path';
+import { ISurvey } from '../../../../backend/src/models';
 
 interface Props {
   /** To control visibility */
   hidden: boolean;
   /** The road data to display */
   roadData?: IRoad;
+  /** The survey data to display */
+  surveyData?: ISurvey;
 }
 /**
  * A components that renders the info card when users click on a road with data
- *
- * @author Chen
+ * Additionally, when selecting a survey, an info card will appear with survey ID & timestamp
+ * @author Chen, Lyons
  */
-const InfoCard: React.FC<Props> = ({ hidden, roadData }) => {
+const InfoCard: React.FC<Props> = ({ hidden, roadData, surveyData }) => {
   const navigate = useNavigate(); // Get the navigate function
 
-  // Navigate to the "Inspect" page
   const handleInspect = useCallback(() => {
-    if (!roadData) return;
-    const biggestBranch = roadData?.branches.reduce((prev, curr) =>
-      prev.length > curr.length ? prev : curr,
-    );
+    // Determine whether to navigate to road or survey inspect page
+    if (roadData) {
+      const biggestBranch = roadData.branches.reduce((prev, curr) =>
+        prev.length > curr.length ? prev : curr,
+      );
+      navigate('/inspect/paths/' + biggestBranch.join(','), {
+        state: { name: roadData.way_name },
+      });
+    } else if (surveyData) {
+      navigate(`/inspect/surveys/${surveyData.id}`, {
+        state: { name: new Date(surveyData.timestamp).toLocaleDateString() },
+      });
+    }
+  }, [roadData, surveyData, navigate]);
 
-    navigate('/inspect/paths/' + biggestBranch.join(','), {
-      state: { name: roadData.way_name },
-    });
-  }, [roadData, navigate]);
-
-  if (hidden || !roadData) {
-    return null; // Don't render anything if hidden is true
+  if (hidden || (!roadData && !surveyData)) {
+    return null;
   }
 
   return (
     <div className="roadinfo-card-content">
-      <div className="roadinfo-text-container">
-        <div className="roadinfo-card-text">
-          <span className="text-title">Road Name:</span>{' '}
-          <span className="card-road-name">{roadData.way_name}</span>
+      {roadData && (
+        <div className="roadinfo-text-container">
+          <div className="roadinfo-card-text">
+            <span className="text-title">Road Name:</span>{' '}
+            <span className="card-road-name">{roadData.way_name}</span>
+          </div>
+          <div className="roadinfo-card-text">
+            <span className="text-title"> Branch Number: </span>
+            <span className="card-road-length">{roadData.branches.length}</span>
+          </div>
         </div>
-        <div className="roadinfo-card-text">
-          <span className="text-title"> Branch Number: </span>
-          <span className="card-road-length"> {roadData.branches.length} </span>
+      )}
+      {surveyData && (
+        <div className="roadinfo-text-container">
+          <div className="roadinfo-card-text">
+            <span className="text-title">Survey ID:</span>
+            <span className="card-road-name">{surveyData.id}</span>
+          </div>
+          <div className="roadinfo-card-text">
+            <span className="text-title">Last updated:</span>
+            <span className="card-road-length">
+              {new Date(surveyData.timestamp).toLocaleDateString()}
+            </span>
+          </div>
         </div>
-      </div>
-
+      )}
       <button onClick={handleInspect} className="inspect-button">
         Inspect
       </button>

--- a/frontend/src/Components/Map/Inputs/Hamburger.tsx
+++ b/frontend/src/Components/Map/Inputs/Hamburger.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import '../../../css/Sidebar.css';
 import { getAllSurveyData } from '../../../queries/conditions';
-import { SurveyList } from '../../../../../backend/src/models';
+import { ISurvey, SurveyList } from '../../../../../backend/src/models';
+import InfoCard from '../InfoCard';
 
 interface HamburgerProps {
   /** Indicates if the sidebar is currently open. */
@@ -20,26 +20,33 @@ interface HamburgerProps {
  *
  * @author Lyons
  */
+
+const HEIGHT_OF_EACH_SURVEY_ITEM = 40; // Define this constant if not defined elsewhere
+
 const Hamburger: React.FC<HamburgerProps> = ({ isOpen, toggle }) => {
-  const [surveys, setSurveys] = useState<SurveyList>([]);
-  const navigate = useNavigate();
+  const [surveys, setSurveys] = useState<ISurvey[]>([]);
+  const [selectedSurvey, setSelectedSurvey] = useState<ISurvey | null>(null);
+  const [, setSelectedSurveyPosition] = useState<number>(0);
 
   useEffect(() => {
     getAllSurveyData((data: SurveyList) => {
-      setSurveys(data);
+      const transformedData: ISurvey[] = data.map((survey) => ({
+        id: survey.id,
+        timestamp: survey.timestamp,
+        geometry: [],
+        data: [],
+      }));
+      setSurveys(transformedData);
     });
   }, []);
 
   const handleSurveyClick = useCallback(
-    (surveyId: string, index: number) => {
-      const path = `/inspect/surveys/${surveyId}`;
-      navigate(path, {
-        state: {
-          name: new Date(surveys[index].timestamp).toLocaleDateString(),
-        },
-      });
+    (_surveyId: string, surveyIndex: number) => {
+      setSelectedSurvey(surveys[surveyIndex]);
+      const topPosition = surveyIndex * HEIGHT_OF_EACH_SURVEY_ITEM;
+      setSelectedSurveyPosition(topPosition);
     },
-    [navigate, surveys],
+    [surveys],
   );
 
   return (
@@ -66,6 +73,9 @@ const Hamburger: React.FC<HamburgerProps> = ({ isOpen, toggle }) => {
           )}
         </div>
       </div>
+      {selectedSurvey && (
+        <InfoCard hidden={!isOpen} surveyData={selectedSurvey} />
+      )}
     </>
   );
 };

--- a/frontend/src/css/roadinfo_card.css
+++ b/frontend/src/css/roadinfo_card.css
@@ -2,7 +2,7 @@
 .roadinfo-card-content {
   position: absolute;
   top: 90px;
-  left: 40px;
+  left: 260px;
   background: white;
   padding: 10px;
   border: 1px solid #ccc;

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -26,7 +26,7 @@ import MonthFilter from '../Components/Map/Inputs/MonthFilter';
 import MultiSelector from '../Components/Map/Inputs/MultiSelector';
 import '../css/navbar.css';
 import DetectMapClick from '../Components/Map/Hooks/DetectMapClick';
-import RoadInfoCard from '../Components/Map/InfoCard';
+import InfoCard from '../Components/Map/InfoCard';
 import { useNavigate } from 'react-router-dom';
 import InfoButton from '../Components/Conditions/InfoButton';
 import UploadPanel from '../Components/Conditions/UploadPanel';
@@ -314,7 +314,7 @@ const Main: FC = () => {
           }}
         />
       )}
-      <RoadInfoCard
+      <InfoCard
         hidden={selectedRoadIdx === -1}
         roadData={
           selectedRoadIdx !== -1 && roads ? roads[selectedRoadIdx] : undefined


### PR DESCRIPTION
![ezgif com-video-to-gif](https://github.com/DTU-SE-Group-D/LiRA-Viz/assets/45044551/12f6452a-eb1d-49bb-b2fe-4d47fa62f5cf)

Added an info card after selecting a survey. Currently only displays Timestamp and ID, but will have other information such as KPI, IRI, road name, and street type very shortly. I am following the figma model in terms of the info that should be displayed. The info card smoothly moves along the Y-axis depending on which survey is selected which is nice because it's not too jarring. Similar to road info card, this survey card has an inspect button that will take the user right to the survey. Main component and design is finished. All that is left is plugging in the other information. 

This branch is not ready to be pulled, however, I'm hoping that next push it will be good to go. Thanks.