### PR TITLE
143 seamless change road surface image

### DIFF
--- a/frontend/src/Components/RoadDetails/ImageGallery.tsx
+++ b/frontend/src/Components/RoadDetails/ImageGallery.tsx
@@ -46,7 +46,7 @@ const ImageGallery: React.FC = () => {
   // Function to open the pop-up
   const openImageInPopup = useCallback(
     (imageId: number) => {
-      setCurrentImageIndex(imageId - 1); // Adjust for 0-based index
+      setCurrentImageIndex(imageId);
       setIsImageClickOpen(true);
     },
     [setCurrentImageIndex, setIsImageClickOpen],

--- a/frontend/src/Components/RoadDetails/RoadImage.tsx
+++ b/frontend/src/Components/RoadDetails/RoadImage.tsx
@@ -123,7 +123,6 @@ const RoadImage: React.FC<Props> = ({
       setHasFiltered(true);
       return;
     }
-    console.log('santi00 selectedType: ', selectedType);
 
     setDisplayedImages(
       allImages.filter((image: IImage) => image.type === selectedType),

--- a/frontend/src/Components/RoadDetails/RoadImage.tsx
+++ b/frontend/src/Components/RoadDetails/RoadImage.tsx
@@ -183,7 +183,6 @@ const RoadImage: React.FC<Props> = ({
 
     if (currentlyVisibleImagesForPixels.length > 0) {
       setIndexLastViewed(currentlyVisibleImagesForPixels[0].absoluteIndex);
-      console.log('santi03 indexLastViewed: ', indexLastViewed);
     }
 
     onRoadDistanceChange(getRoadDistances(currentlyVisibleImagesForPixels));

--- a/frontend/src/Components/RoadDetails/RoadImage.tsx
+++ b/frontend/src/Components/RoadDetails/RoadImage.tsx
@@ -181,11 +181,6 @@ const RoadImage: React.FC<Props> = ({
       }
     });
 
-    console.log(
-      'santi02 currentlyVisibleImagesForPixels: ',
-      currentlyVisibleImagesForPixels,
-    );
-
     if (currentlyVisibleImagesForPixels.length > 0) {
       console.log(
         'currentlyVisibleImagesForPixels[0].absoluteIndex',

--- a/frontend/src/Components/RoadDetails/RoadImage.tsx
+++ b/frontend/src/Components/RoadDetails/RoadImage.tsx
@@ -247,9 +247,20 @@ const RoadImage: React.FC<Props> = ({
                   key={'div' + image.id}
                   className="road-image-surface-image"
                   data-image-id={image.id}
-                  ref={index === indexLastViewed ? surfaceContainerRef : null}
                 >
-                  <RotatedImage key={image.id} src={image.image_path} />
+                  <RotatedImage
+                    key={image.id}
+                    src={image.image_path}
+                    onLoad={() => {
+                      if (index === indexLastViewed) {
+                        setTimeout(() => {
+                          if (containerRef.current === null) return;
+                          const container = containerRef.current as HTMLElement;
+                          container.children[index].scrollIntoView();
+                        }, 20);
+                      }
+                    }}
+                  />
                 </div>
               ))
             : null}

--- a/frontend/src/Components/RoadDetails/RoadImage.tsx
+++ b/frontend/src/Components/RoadDetails/RoadImage.tsx
@@ -85,6 +85,8 @@ const RoadImage: React.FC<Props> = ({
   const [allImages, setAllImages] = useState<IImage[]>([]);
   /** The image of the selected type */
   const [displayedImages, setDisplayedImages] = useState<IImage[]>([]);
+
+  const [indexLastViewed, setIndexLastViewed] = useState<number>(0);
   /** The type of image to display */
   const containerRef = useRef(null);
 
@@ -121,6 +123,7 @@ const RoadImage: React.FC<Props> = ({
       setHasFiltered(true);
       return;
     }
+    console.log('santi00 selectedType: ', selectedType);
 
     setDisplayedImages(
       allImages.filter((image: IImage) => image.type === selectedType),
@@ -141,7 +144,7 @@ const RoadImage: React.FC<Props> = ({
     const images = container.querySelectorAll('.road-image-surface-image');
     const currentlyVisibleImagesForPixels: IImageValuesForPixels[] = [];
 
-    images.forEach((image) => {
+    images.forEach((image, index) => {
       const imageRect = image.getBoundingClientRect();
       if (
         imageRect.right >= containerRect.left &&
@@ -173,10 +176,26 @@ const RoadImage: React.FC<Props> = ({
               imageRect.right > roadSurfaceImageDivRightPixel
                 ? roadSurfaceImageDivRightPixel
                 : imageRect.right,
+            absoluteIndex: index,
           });
         }
       }
     });
+
+    console.log(
+      'santi02 currentlyVisibleImagesForPixels: ',
+      currentlyVisibleImagesForPixels,
+    );
+
+    if (currentlyVisibleImagesForPixels.length > 0) {
+      console.log(
+        'currentlyVisibleImagesForPixels[0].absoluteIndex',
+        currentlyVisibleImagesForPixels[0].absoluteIndex,
+      );
+      setIndexLastViewed(currentlyVisibleImagesForPixels[0].absoluteIndex);
+      console.log('santi03 indexLastViewed: ', indexLastViewed);
+    }
+
     onRoadDistanceChange(getRoadDistances(currentlyVisibleImagesForPixels));
   }, [containerRef, onRoadDistanceChange, displayedImages]);
 
@@ -223,11 +242,12 @@ const RoadImage: React.FC<Props> = ({
       <div className="border-road-image-surface-container">
         <div ref={containerRef} className="road-image-surface-container">
           {displayedImages.length > 0
-            ? displayedImages.slice(0, 25).map((image) => (
+            ? displayedImages.slice(0, 25).map((image, index) => (
                 <div
                   key={'div' + image.id}
                   className="road-image-surface-image"
                   data-image-id={image.id}
+                  ref={index === indexLastViewed ? surfaceContainerRef : null}
                 >
                   <RotatedImage key={image.id} src={image.image_path} />
                 </div>

--- a/frontend/src/Components/RoadDetails/RoadImage.tsx
+++ b/frontend/src/Components/RoadDetails/RoadImage.tsx
@@ -182,10 +182,6 @@ const RoadImage: React.FC<Props> = ({
     });
 
     if (currentlyVisibleImagesForPixels.length > 0) {
-      console.log(
-        'currentlyVisibleImagesForPixels[0].absoluteIndex',
-        currentlyVisibleImagesForPixels[0].absoluteIndex,
-      );
       setIndexLastViewed(currentlyVisibleImagesForPixels[0].absoluteIndex);
       console.log('santi03 indexLastViewed: ', indexLastViewed);
     }

--- a/frontend/src/Components/RoadDetails/RotatedImage.tsx
+++ b/frontend/src/Components/RoadDetails/RotatedImage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 interface Props {
   /** The path of the image to display */
   src: string;
+  onLoad?: () => void;
 }
 
 /**
@@ -11,7 +12,7 @@ interface Props {
  * @param src The path of the image to display
  * @author Kerbourc'h
  */
-const RotatedImage: React.FC<Props> = ({ src }) => {
+const RotatedImage: React.FC<Props> = ({ src, onLoad }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [width, setWidth] = useState<number>(0);
 
@@ -35,6 +36,8 @@ const RotatedImage: React.FC<Props> = ({ src }) => {
       ctx.translate(canvas.width / 2, canvas.height / 2);
       ctx.rotate((Math.PI / 180) * 90);
       ctx.drawImage(image, -image.width / 2, -image.height / 2);
+
+      if (onLoad) onLoad();
     };
   }, [canvasRef, src]);
 

--- a/frontend/src/models/models.ts
+++ b/frontend/src/models/models.ts
@@ -32,6 +32,7 @@ export interface IImageValuesForPixels {
   pixelWidth: number;
   firstVisiblePixelLeft: number;
   lastVisiblePixelRight: number;
+  absoluteIndex: number;
 }
 
 export interface Conditions {


### PR DESCRIPTION
now in inspect page when user changes type of road surface images to show it will stay approximately at the same distance of where it was and not starting to zero.


**WAIT** 
_FIRST PR ABOUT ROTATION OF IMAGES FROM BE HAS TO BE MERGED_